### PR TITLE
Add Tools submenu to main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The following device roles have been working:
 - **Statistics**: View statistics about nodes, hardware, and roles.
 - **Wall of Shame**: View devices with low battery levels.
 - **Fortune Teller**: Get a random fortune. Pulls from the fortunes.txt file. Feel free to edit this file remove or add more if you like.
+- **Tools Menu**: Placeholder for future tools.
 
 ## Usage
 

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -24,6 +24,7 @@ config.read('config.ini')
 main_menu_items = config['menu']['main_menu_items'].split(',')
 bbs_menu_items = config['menu']['bbs_menu_items'].split(',')
 utilities_menu_items = config['menu']['utilities_menu_items'].split(',')
+tools_menu_items = config['menu'].get('tools_menu_items', 'X').split(',')
 
 
 def build_menu(items, menu_name):
@@ -38,6 +39,8 @@ def build_menu(items, menu_name):
                 menu_str += "[B]BS\n"
         elif item.strip() == 'U':
             menu_str += "[U]tilities\n"
+        elif item.strip() == 'T':
+            menu_str += "[T]ools\n"
         elif item.strip() == 'X':
             menu_str += "E[X]IT\n"
         elif item.strip() == 'M':
@@ -110,6 +113,26 @@ def handle_fortune_command(sender_id, interface):
         send_message(decorated_fortune, sender_id, interface)
     except Exception as e:
         send_message(f"Error generating fortune: {e}", sender_id, interface)
+
+
+def handle_tools_command(sender_id, interface):
+    """Display the tools menu (placeholder)."""
+    response = "🧰Tools Menu🧰\nNo tools available yet.\nE[X]IT"
+    send_message(response, sender_id, interface)
+    update_user_state(sender_id, {'command': 'TOOLS', 'step': 1})
+
+
+def handle_tools_steps(sender_id, message, step, interface):
+    message = message.lower().strip()
+    if len(message) == 2 and message[1] == 'x':
+        message = message[0]
+
+    if step == 1:
+        if message == 'x':
+            handle_help_command(sender_id, interface)
+        else:
+            send_message("No tools implemented yet.", sender_id, interface)
+            handle_tools_command(sender_id, interface)
 
 
 def handle_stats_steps(sender_id, message, step, interface):

--- a/example_config.ini
+++ b/example_config.ini
@@ -57,10 +57,11 @@ type = serial
 # [Q]uick Commands
 # [B]BS
 # [U]tilities
+# [T]ools
 # E[X]IT
 #
 # Remove any menu items from the list below that you want to exclude from the main menu
-main_menu_items = Q, B, U, X
+main_menu_items = Q, B, U, T, X
 
 # Default BBS Menu options for reference
 # [M]ail
@@ -80,6 +81,11 @@ bbs_menu_items = M, B, C, J, X
 #
 # Remove any menu items from the list below that you want to exclude from the utilities menu
 utilities_menu_items = S, F, W, X
+
+# Default Tools Menu option for reference
+# E[X]IT
+# Remove any menu items from the list below that you want to exclude from the tools menu
+tools_menu_items = X
 
 
 ##########################

--- a/message_processing.py
+++ b/message_processing.py
@@ -8,7 +8,8 @@ from command_handlers import (
     handle_channel_directory_command, handle_channel_directory_steps, handle_send_mail_command,
     handle_read_mail_command, handle_check_mail_command, handle_delete_mail_confirmation, handle_post_bulletin_command,
     handle_check_bulletin_command, handle_read_bulletin_command, handle_read_channel_command,
-    handle_post_channel_command, handle_list_channels_command, handle_quick_help_command
+    handle_post_channel_command, handle_list_channels_command, handle_quick_help_command,
+    handle_tools_command, handle_tools_steps
 )
 from db_operations import add_bulletin, add_mail, delete_bulletin, delete_mail, get_db_connection, add_channel
 from js8call_integration import handle_js8call_command, handle_js8call_steps, handle_group_message_selection
@@ -18,6 +19,7 @@ main_menu_handlers = {
     "q": handle_quick_help_command,
     "b": lambda sender_id, interface: handle_help_command(sender_id, interface, 'bbs'),
     "u": lambda sender_id, interface: handle_help_command(sender_id, interface, 'utilities'),
+    "t": handle_tools_command,
     "x": handle_help_command
 }
 
@@ -34,6 +36,11 @@ utilities_menu_handlers = {
     "s": handle_stats_command,
     "f": handle_fortune_command,
     "w": handle_wall_of_shame_command,
+    "x": handle_help_command
+}
+
+
+tools_menu_handlers = {
     "x": handle_help_command
 }
 
@@ -115,6 +122,8 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                 handlers = bulletin_menu_handlers
             elif state and state['command'] == 'BULLETIN_ACTION':
                 handlers = board_action_handlers
+            elif state and state['command'] == 'TOOLS':
+                handlers = tools_menu_handlers
             elif state and state['command'] == 'JS8CALL_MENU':
                 handle_js8call_steps(sender_id, message, state['step'], interface, state)
                 return
@@ -168,6 +177,8 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                     handle_bb_steps(sender_id, message, 3, state, interface, bbs_nodes)
                 elif command == 'JS8CALL_MENU':
                     handle_js8call_steps(sender_id, message, step, interface, state)
+                elif command == 'TOOLS':
+                    handle_tools_steps(sender_id, message, step, interface)
                 elif command == 'GROUP_MESSAGES':
                     handle_group_message_selection(sender_id, message, step, state, interface)
                 else:


### PR DESCRIPTION
## Summary
- expand configuration with Tools menu items
- add Tools menu handler and menu processing logic
- include placeholder Tools submenu implementation
- document new menu in README

## Testing
- `python -m py_compile command_handlers.py message_processing.py config_init.py server.py utils.py db_admin.py db_operations.py js8call_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68804e08473c8321a18a32fff4893bee