### PR TITLE
Add Games submenu framework

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -25,6 +25,7 @@ main_menu_items = config['menu']['main_menu_items'].split(',')
 bbs_menu_items = config['menu']['bbs_menu_items'].split(',')
 utilities_menu_items = config['menu']['utilities_menu_items'].split(',')
 tools_menu_items = config['menu'].get('tools_menu_items', 'X').split(',')
+games_menu_items = config['menu'].get('games_menu_items', 'D,X').split(',')
 
 
 def build_menu(items, menu_name):
@@ -55,6 +56,10 @@ def build_menu(items, menu_name):
             menu_str += "[F]ortune\n"
         elif item.strip() == 'W':
             menu_str += "[W]all of Shame\n"
+        elif item.strip() == 'G':
+            menu_str += "[G]ames\n"
+        elif item.strip() == 'D':
+            menu_str += "[D]opewars\n"
     return menu_str
 
 def handle_help_command(sender_id, interface, menu_name=None):
@@ -64,6 +69,8 @@ def handle_help_command(sender_id, interface, menu_name=None):
             response = build_menu(bbs_menu_items, "📰BBS Menu📰")
         elif menu_name == 'utilities':
             response = build_menu(utilities_menu_items, "🛠️Utilities Menu🛠️")
+        elif menu_name == 'games':
+            response = build_menu(games_menu_items, "🎮Games Menu🎮")
     else:
         update_user_state(sender_id, {'command': 'MAIN_MENU', 'step': 1})  # Reset to main menu state
         mail = get_mail(get_node_id_from_num(sender_id, interface))
@@ -133,6 +140,47 @@ def handle_tools_steps(sender_id, message, step, interface):
         else:
             send_message("No tools implemented yet.", sender_id, interface)
             handle_tools_command(sender_id, interface)
+
+
+def handle_games_command(sender_id, interface):
+    """Display the games menu."""
+    response = build_menu(games_menu_items, "🎮Games Menu🎮")
+    send_message(response, sender_id, interface)
+    update_user_state(sender_id, {'command': 'GAMES', 'step': 1})
+
+
+def handle_games_steps(sender_id, message, step, interface):
+    message = message.lower().strip()
+    if len(message) == 2 and message[1] == 'x':
+        message = message[0]
+
+    if step == 1:
+        if message == 'x':
+            handle_help_command(sender_id, interface)
+        elif message == 'd':
+            handle_dopewars_command(sender_id, interface)
+        else:
+            send_message("Invalid option. Please choose again.", sender_id, interface)
+            handle_games_command(sender_id, interface)
+
+
+def handle_dopewars_command(sender_id, interface):
+    """Placeholder for Dopewars game."""
+    send_message("Dopewars is not yet implemented.", sender_id, interface)
+    update_user_state(sender_id, {'command': 'DOPEWARS', 'step': 1})
+
+
+def handle_dopewars_steps(sender_id, message, step, interface):
+    message = message.lower().strip()
+    if len(message) == 2 and message[1] == 'x':
+        message = message[0]
+
+    if step == 1:
+        if message == 'x':
+            handle_games_command(sender_id, interface)
+        else:
+            send_message("Dopewars is under construction.", sender_id, interface)
+            handle_dopewars_command(sender_id, interface)
 
 
 def handle_stats_steps(sender_id, message, step, interface):

--- a/example_config.ini
+++ b/example_config.ini
@@ -61,7 +61,7 @@ type = serial
 # E[X]IT
 #
 # Remove any menu items from the list below that you want to exclude from the main menu
-main_menu_items = Q, B, U, T, X
+main_menu_items = Q, B, U, T, G, X
 
 # Default BBS Menu options for reference
 # [M]ail
@@ -86,6 +86,7 @@ utilities_menu_items = S, F, W, X
 # E[X]IT
 # Remove any menu items from the list below that you want to exclude from the tools menu
 tools_menu_items = X
+games_menu_items = D, X
 
 
 ##########################

--- a/message_processing.py
+++ b/message_processing.py
@@ -9,7 +9,9 @@ from command_handlers import (
     handle_read_mail_command, handle_check_mail_command, handle_delete_mail_confirmation, handle_post_bulletin_command,
     handle_check_bulletin_command, handle_read_bulletin_command, handle_read_channel_command,
     handle_post_channel_command, handle_list_channels_command, handle_quick_help_command,
-    handle_tools_command, handle_tools_steps
+    handle_tools_command, handle_tools_steps,
+    handle_games_command, handle_games_steps,
+    handle_dopewars_command, handle_dopewars_steps
 )
 from db_operations import add_bulletin, add_mail, delete_bulletin, delete_mail, get_db_connection, add_channel
 from js8call_integration import handle_js8call_command, handle_js8call_steps, handle_group_message_selection
@@ -20,6 +22,7 @@ main_menu_handlers = {
     "b": lambda sender_id, interface: handle_help_command(sender_id, interface, 'bbs'),
     "u": lambda sender_id, interface: handle_help_command(sender_id, interface, 'utilities'),
     "t": handle_tools_command,
+    "g": handle_games_command,
     "x": handle_help_command
 }
 
@@ -41,6 +44,12 @@ utilities_menu_handlers = {
 
 
 tools_menu_handlers = {
+    "x": handle_help_command
+}
+
+
+games_menu_handlers = {
+    "d": handle_dopewars_command,
     "x": handle_help_command
 }
 
@@ -116,6 +125,8 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                     handlers = bbs_menu_handlers
                 elif menu_name == 'utilities':
                     handlers = utilities_menu_handlers
+                elif menu_name == 'games':
+                    handlers = games_menu_handlers
                 else:
                     handlers = main_menu_handlers
             elif state and state['command'] == 'BULLETIN_MENU':
@@ -124,6 +135,8 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                 handlers = board_action_handlers
             elif state and state['command'] == 'TOOLS':
                 handlers = tools_menu_handlers
+            elif state and state['command'] == 'GAMES':
+                handlers = games_menu_handlers
             elif state and state['command'] == 'JS8CALL_MENU':
                 handle_js8call_steps(sender_id, message, state['step'], interface, state)
                 return
@@ -179,6 +192,10 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                     handle_js8call_steps(sender_id, message, step, interface, state)
                 elif command == 'TOOLS':
                     handle_tools_steps(sender_id, message, step, interface)
+                elif command == 'GAMES':
+                    handle_games_steps(sender_id, message, step, interface)
+                elif command == 'DOPEWARS':
+                    handle_dopewars_steps(sender_id, message, step, interface)
                 elif command == 'GROUP_MESSAGES':
                     handle_group_message_selection(sender_id, message, step, state, interface)
                 else:


### PR DESCRIPTION
## Summary
- add games menu configuration option
- implement games menu logic with Dopewars placeholder
- support new games submenu in message processing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68817183d80c83218423892bf0983575