### PR TITLE
Add configurable message delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,16 @@ If you're a Docker user, BBMesh is available on Docker Hub!
    Windows Example:  
    `port = COM3`   
    
-   If using type = tcp you will need to uncomment the hostname = 192.168.x.x line and put in the IP address of your Meshtastic device.  
-   
-   **[sync]**  
-   Enter a list of other BBS nodes you would like to sync messages and bulletins with. Separate each by comma and no spaces as shown in the example below.   
+   If using type = tcp you will need to uncomment the hostname = 192.168.x.x line and put in the IP address of your Meshtastic device.
+
+   **[sync]**
+   Enter a list of other BBS nodes you would like to sync messages and bulletins with. Separate each by comma and no spaces as shown in the example below.
    You can find the nodeID in the menu under `Radio Configuration > User` for each node, or use this script for getting nodedb data from a device:  
    
-   [Meshtastic-Python-Examples/print-nodedb.py at main · pdxlocations/Meshtastic-Python-Examples (github.com)](https://github.com/pdxlocations/Meshtastic-Python-Examples/blob/main/print-nodedb.py)  
+   [Meshtastic-Python-Examples/print-nodedb.py at main · pdxlocations/Meshtastic-Python-Examples (github.com)](https://github.com/pdxlocations/Meshtastic-Python-Examples/blob/main/print-nodedb.py)
+
+   **[settings]**
+   `message_delay_ms` controls the pause in milliseconds between split message packets.
    
    Example Config:  
    
@@ -101,8 +104,11 @@ If you're a Docker user, BBMesh is available on Docker Hub!
    # port = /dev/ttyUSB0  
    # hostname = 192.168.x.x  
    
-   [sync]  
-   bbs_nodes = !f53f4abc,!f3abc123  
+   [sync]
+   bbs_nodes = !f53f4abc,!f3abc123
+
+   [settings]
+   message_delay_ms = 50
    ```
 
 ### Running the Server

--- a/config_init.py
+++ b/config_init.py
@@ -118,6 +118,8 @@ def initialize_config(config_file: str = None) -> dict[str, Any]:
     if allowed_nodes == ['']:
         allowed_nodes = []
 
+    message_delay_ms = config.getint('settings', 'message_delay_ms', fallback=50)
+
     print(f"Nodes with Urgent board permissions: {allowed_nodes}")
 
     return {
@@ -127,7 +129,8 @@ def initialize_config(config_file: str = None) -> dict[str, Any]:
         'port': port,
         'bbs_nodes': bbs_nodes,
         'allowed_nodes': allowed_nodes,
-        'mqtt_topic': 'meshtastic.receive'
+        'mqtt_topic': 'meshtastic.receive',
+        'message_delay_ms': message_delay_ms
     }
 
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -47,6 +47,14 @@ type = serial
 # allowed_nodes = !17d7e4b7
 
 
+#######################
+#### BBS Settings ####
+#######################
+# Delay in milliseconds between packets when sending split messages
+[settings]
+message_delay_ms = 50
+
+
 ####################
 #### Menu Items ####
 ####################

--- a/server.py
+++ b/server.py
@@ -62,6 +62,7 @@ def main():
     interface = get_interface(system_config)
     interface.bbs_nodes = system_config['bbs_nodes']
     interface.allowed_nodes = system_config['allowed_nodes']
+    interface.message_delay = system_config.get('message_delay_ms', 50) / 1000.0
 
     logging.info(f"BBMesh is running on {system_config['interface_type']} interface...")
 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,10 @@
 import logging
 import time
+import configparser
+
+_config = configparser.ConfigParser()
+_config.read('config.ini')
+DEFAULT_DELAY_MS = _config.getint('settings', 'message_delay_ms', fallback=50)
 
 user_states = {}
 
@@ -33,7 +38,8 @@ def send_message(message, destination, interface):
             logging.info(f"REPLY SEND ERROR {e.message}")
 
         
-        time.sleep(2)
+        delay_sec = getattr(interface, 'message_delay', DEFAULT_DELAY_MS / 1000.0)
+        time.sleep(delay_sec)
 
 
 def get_node_info(interface, short_name):


### PR DESCRIPTION
## Summary
- allow pausing between packets when splitting a message
- set the pause interval with `message_delay_ms` in config
- document `message_delay_ms` in README and example config

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68822c466af483219bcb6e8e35a0139c