### PR TITLE
Make split message length configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you're a Docker user, BBMesh is available on Docker Hub!
 
    **[settings]**
    `message_delay_ms` controls the pause in milliseconds between split message packets.
+   `message_split_len` sets how many characters are sent in each piece of a split message. The default of 60 keeps packets under the radio limit.
    
    Example Config:  
    
@@ -109,6 +110,7 @@ If you're a Docker user, BBMesh is available on Docker Hub!
 
    [settings]
    message_delay_ms = 50
+   message_split_len = 60
    ```
 
 ### Running the Server

--- a/config_init.py
+++ b/config_init.py
@@ -119,6 +119,7 @@ def initialize_config(config_file: str = None) -> dict[str, Any]:
         allowed_nodes = []
 
     message_delay_ms = config.getint('settings', 'message_delay_ms', fallback=50)
+    message_split_len = config.getint('settings', 'message_split_len', fallback=60)
 
     print(f"Nodes with Urgent board permissions: {allowed_nodes}")
 
@@ -130,7 +131,8 @@ def initialize_config(config_file: str = None) -> dict[str, Any]:
         'bbs_nodes': bbs_nodes,
         'allowed_nodes': allowed_nodes,
         'mqtt_topic': 'meshtastic.receive',
-        'message_delay_ms': message_delay_ms
+        'message_delay_ms': message_delay_ms,
+        'message_split_len': message_split_len
     }
 
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -51,8 +51,10 @@ type = serial
 #### BBS Settings ####
 #######################
 # Delay in milliseconds between packets when sending split messages
+# Max characters for each piece of a split message
 [settings]
 message_delay_ms = 50
+message_split_len = 60
 
 
 ####################

--- a/server.py
+++ b/server.py
@@ -63,6 +63,7 @@ def main():
     interface.bbs_nodes = system_config['bbs_nodes']
     interface.allowed_nodes = system_config['allowed_nodes']
     interface.message_delay = system_config.get('message_delay_ms', 50) / 1000.0
+    interface.message_split_len = system_config.get('message_split_len', 60)
 
     logging.info(f"BBMesh is running on {system_config['interface_type']} interface...")
 

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,7 @@ import configparser
 _config = configparser.ConfigParser()
 _config.read('config.ini')
 DEFAULT_DELAY_MS = _config.getint('settings', 'message_delay_ms', fallback=50)
+DEFAULT_SPLIT_LEN = _config.getint('settings', 'message_split_len', fallback=60)
 
 user_states = {}
 
@@ -21,7 +22,7 @@ def send_message(message, destination, interface):
     # The radio hardware truncates messages longer than 63 characters. To
     # ensure complete delivery we send messages in chunks slightly below
     # that limit.
-    max_payload_size = 60
+    max_payload_size = getattr(interface, 'message_split_len', DEFAULT_SPLIT_LEN)
     for i in range(0, len(message), max_payload_size):
         chunk = message[i:i + max_payload_size]
         try:


### PR DESCRIPTION
## Summary
- allow configuring split message length through `settings.message_split_len`
- expose message_split_len to modules through system configuration
- mention the new option in README
- update example config

## Testing
- `python -m py_compile utils.py server.py config_init.py`

------
https://chatgpt.com/codex/tasks/task_e_68823275aed88321ae6b0222d4ca9a8b