### PR TITLE
Add Tradewars menu placeholder

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -42,7 +42,10 @@ def build_menu(items, menu_name):
         elif item.strip() == 'U':
             menu_str += "[U]tilities\n"
         elif item.strip() == 'T':
-            menu_str += "[T]ools\n"
+            if menu_name == "🎮Games Menu🎮":
+                menu_str += "[T]radewars\n"
+            else:
+                menu_str += "[T]ools\n"
         elif item.strip() == 'X':
             menu_str += "E[X]IT\n"
         elif item.strip() == 'M':
@@ -160,6 +163,8 @@ def handle_games_steps(sender_id, message, step, interface):
             handle_help_command(sender_id, interface)
         elif message == 'd':
             handle_dopewars_command(sender_id, interface)
+        elif message == 't':
+            handle_tradewars_command(sender_id, interface)
         else:
             send_message("Invalid option. Please choose again.", sender_id, interface)
             handle_games_command(sender_id, interface)
@@ -192,6 +197,25 @@ def handle_dopewars_steps(sender_id, message, step, interface):
         handle_help_command(sender_id, interface)
     else:
         update_user_state(sender_id, {'command': 'DOPEWARS', 'step': 1})
+
+
+def handle_tradewars_command(sender_id, interface):
+    """Enter the Tradewars game."""
+    # Placeholder for future Tradewars integration
+    send_message("Tradewars is not implemented yet.", sender_id, interface)
+    update_user_state(sender_id, {'command': 'TRADEWARS', 'step': 1})
+
+
+def handle_tradewars_steps(sender_id, message, step, interface):
+    message = message.strip()
+    if len(message) == 2 and message[1].lower() == 'x':
+        message = message[0]
+
+    if message.lower() == 'x':
+        handle_help_command(sender_id, interface)
+    else:
+        send_message("Tradewars is not implemented yet.", sender_id, interface)
+        handle_help_command(sender_id, interface)
 
 
 def handle_stats_steps(sender_id, message, step, interface):

--- a/example_config.ini
+++ b/example_config.ini
@@ -96,7 +96,7 @@ utilities_menu_items = S, F, W, X
 # E[X]IT
 # Remove any menu items from the list below that you want to exclude from the tools menu
 tools_menu_items = X
-games_menu_items = D, X
+games_menu_items = D, T, X
 
 
 ##########################

--- a/message_processing.py
+++ b/message_processing.py
@@ -11,7 +11,8 @@ from command_handlers import (
     handle_post_channel_command, handle_list_channels_command, handle_quick_help_command,
     handle_tools_command, handle_tools_steps,
     handle_games_command, handle_games_steps,
-    handle_dopewars_command, handle_dopewars_steps
+    handle_dopewars_command, handle_dopewars_steps,
+    handle_tradewars_command, handle_tradewars_steps
 )
 from db_operations import add_bulletin, add_mail, delete_bulletin, delete_mail, get_db_connection, add_channel
 from js8call_integration import handle_js8call_command, handle_js8call_steps, handle_group_message_selection
@@ -50,6 +51,7 @@ tools_menu_handlers = {
 
 games_menu_handlers = {
     "d": handle_dopewars_command,
+    "t": handle_tradewars_command,
     "x": handle_help_command
 }
 
@@ -196,6 +198,8 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                     handle_games_steps(sender_id, message, step, interface)
                 elif command == 'DOPEWARS':
                     handle_dopewars_steps(sender_id, message, step, interface)
+                elif command == 'TRADEWARS':
+                    handle_tradewars_steps(sender_id, message, step, interface)
                 elif command == 'GROUP_MESSAGES':
                     handle_group_message_selection(sender_id, message, step, state, interface)
                 else:


### PR DESCRIPTION
## Summary
- support Tradewars entry in the games menu
- add placeholder handlers for Tradewars
- show `[T]radewars` when building the games menu
- route `t` game input to Tradewars
- update example config

## Testing
- `python -m py_compile command_handlers.py message_processing.py`

------
https://chatgpt.com/codex/tasks/task_e_6882796389a08321b620bfce419bae66