### PR TITLE
Add simple TradeWars wrapper

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -5,6 +5,7 @@ import time
 
 from meshtastic import BROADCAST_NUM
 from dopewars import playDopeWars, dwGameDayDb
+from tradewars_interface import play_tradewars, _player_states
 
 from db_operations import (
     add_bulletin, add_mail, delete_mail,
@@ -160,6 +161,8 @@ def handle_games_steps(sender_id, message, step, interface):
             handle_help_command(sender_id, interface)
         elif message == 'd':
             handle_dopewars_command(sender_id, interface)
+        elif message == 't':
+            handle_tradewars_command(sender_id, interface)
         else:
             send_message("Invalid option. Please choose again.", sender_id, interface)
             handle_games_command(sender_id, interface)
@@ -192,6 +195,31 @@ def handle_dopewars_steps(sender_id, message, step, interface):
         handle_help_command(sender_id, interface)
     else:
         update_user_state(sender_id, {'command': 'DOPEWARS', 'step': 1})
+
+
+def handle_tradewars_command(sender_id, interface):
+    """Enter the Tradewars game."""
+    node_id = get_node_id_from_num(sender_id, interface)
+    response = play_tradewars(node_id, "")
+    send_message(response, sender_id, interface)
+    update_user_state(sender_id, {'command': 'TRADEWARS', 'step': 1})
+
+
+def handle_tradewars_steps(sender_id, message, step, interface):
+    message = message.strip()
+    if len(message) == 2 and message[1].lower() == 'x':
+        message = message[0]
+
+    node_id = get_node_id_from_num(sender_id, interface)
+    response = play_tradewars(node_id, message)
+    send_message(response, sender_id, interface)
+
+    in_game = node_id in _player_states
+
+    if not in_game:
+        handle_help_command(sender_id, interface)
+    else:
+        update_user_state(sender_id, {'command': 'TRADEWARS', 'step': 1})
 
 
 def handle_stats_steps(sender_id, message, step, interface):

--- a/example_config.ini
+++ b/example_config.ini
@@ -96,7 +96,7 @@ utilities_menu_items = S, F, W, X
 # E[X]IT
 # Remove any menu items from the list below that you want to exclude from the tools menu
 tools_menu_items = X
-games_menu_items = D, X
+games_menu_items = T, D, X
 
 
 ##########################

--- a/message_processing.py
+++ b/message_processing.py
@@ -11,7 +11,8 @@ from command_handlers import (
     handle_post_channel_command, handle_list_channels_command, handle_quick_help_command,
     handle_tools_command, handle_tools_steps,
     handle_games_command, handle_games_steps,
-    handle_dopewars_command, handle_dopewars_steps
+    handle_dopewars_command, handle_dopewars_steps,
+    handle_tradewars_command, handle_tradewars_steps
 )
 from db_operations import add_bulletin, add_mail, delete_bulletin, delete_mail, get_db_connection, add_channel
 from js8call_integration import handle_js8call_command, handle_js8call_steps, handle_group_message_selection
@@ -49,6 +50,7 @@ tools_menu_handlers = {
 
 
 games_menu_handlers = {
+    "t": handle_tradewars_command,
     "d": handle_dopewars_command,
     "x": handle_help_command
 }
@@ -196,6 +198,8 @@ def process_message(sender_id, message, interface, is_sync_message=False):
                     handle_games_steps(sender_id, message, step, interface)
                 elif command == 'DOPEWARS':
                     handle_dopewars_steps(sender_id, message, step, interface)
+                elif command == 'TRADEWARS':
+                    handle_tradewars_steps(sender_id, message, step, interface)
                 elif command == 'GROUP_MESSAGES':
                     handle_group_message_selection(sender_id, message, step, state, interface)
                 else:

--- a/tradewars_interface.py
+++ b/tradewars_interface.py
@@ -1,0 +1,58 @@
+"""Simplified Tradewars interface used by BBMesh."""
+
+import random
+
+# Per-player game states
+_player_states = {}
+
+
+def _new_game(node_id):
+    """Initialize a new game state."""
+    _player_states[node_id] = {
+        "sector": 1,
+        "credits": 1000,
+        "step": "start",
+    }
+
+
+def play_tradewars(node_id: int, cmd: str) -> str:
+    """Handle a single tradewars command.
+
+    This is a very small wrapper that mimics the behaviour of the real
+    Tradewars game. It keeps state in a module level dictionary and
+    returns a string response for the BBS to send back to the user.
+
+    Parameters
+    ----------
+    node_id: int
+        Unique node identifier of the player.
+    cmd: str
+        Command text provided by the player. A blank string is used when
+        the player first enters the game.
+
+    Returns
+    -------
+    str
+        Text that should be sent back to the user.
+    """
+    state = _player_states.get(node_id)
+    if state is None:
+        _new_game(node_id)
+        return (
+            "Welcome to TradeWars!\n"
+            "(M)ove  (C)heck stats  E(X)IT"
+        )
+
+    cmd = cmd.strip().lower()
+    if cmd == "x":
+        _player_states.pop(node_id, None)
+        return "Exiting TradeWars."
+    elif cmd.startswith("m"):
+        # Move to a random neighbouring sector
+        state["sector"] += random.randint(1, 5)
+        return f"Warped to sector {state['sector']}."
+    elif cmd == "c":
+        return f"Sector {state['sector']} - Credits: {state['credits']}"
+    else:
+        return "Unknown command. (M)ove, (C)heck, or E(X)IT"
+


### PR DESCRIPTION
## Summary
- create `tradewars_interface` with a small stateful game stub
- wire TradeWars into command handlers and message processing
- expose TradeWars in the example config

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile tradewars_interface.py command_handlers.py message_processing.py`


------
https://chatgpt.com/codex/tasks/task_e_68827965f40c83219e19118fa8c39c7b