### PR TITLE
Add Tradewars docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,19 @@ options:
   --mqtt-topic MQTT_TOPIC, -t MQTT_TOPIC
                         MQTT topic to subscribe
 ```
+### Tradewars Server
+
+BBMesh includes a text-based Tradewars game. The game runs as a separate TCP server and is started automatically when a player selects Tradewars from the Games menu.
+
+To use it, install the additional dependencies and optionally start the server manually:
+
+```sh
+pip install numpy pandas
+python tradewars_server.py
+```
+
+The server listens on the port configured in the `[tradewars]` section of `config.ini`. You can also set the path to the Tradewars executable there.
+
 
 
 

--- a/example_config.ini
+++ b/example_config.ini
@@ -117,3 +117,13 @@ games_menu_items = D, T, X
 # js8groups = @GRP1,@GRP2,@GRP3
 # store_messages = True
 # js8urgent = @URGNT
+
+############################
+#### Tradewars Settings ####
+############################
+# Configuration for the Tradewars game server
+# Set the TCP port the server listens on and the path to the game executable
+
+[tradewars]
+port = 4242
+path = tradewars.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 meshtastic
 pypubsub
+
+numpy
+pandas


### PR DESCRIPTION
## Summary
- document Tradewars game server
- add Tradewars section to example config
- list numpy/pandas dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6882994048608321855aa115adc1da40