### PR TITLE
Notify players when starting Tradewars

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -205,6 +205,7 @@ def handle_dopewars_steps(sender_id, message, step, interface):
 def handle_tradewars_command(sender_id, interface):
     """Enter the Tradewars game."""
     if not tradewars_server_alive(TW_PORT):
+        send_message("Starting Tradewars server...", sender_id, interface)
         if not start_tradewars_server(TW_PORT):
             logging.error("Unable to start TradeWars server")
             send_message("Unable to start Tradewars.", sender_id, interface)


### PR DESCRIPTION
## Summary
- notify players if the Tradewars server needs to be started

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6882a0c2ca50832190870a9b6c3efa95