### PR TITLE
Handle empty Tradewars output

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -258,10 +258,12 @@ def handle_tradewars_steps(sender_id, message, step, interface):
         try:
             data = sock.recv(4096)
             if data == b"":
-                raise ConnectionError("Server disconnected")
-            reply = data.decode()
+                logging.info("No output received from Tradewars server.")
+                reply = ""
+            else:
+                reply = data.decode()
         except socket.timeout:
-            # Treat timeouts as no data rather than an error
+            logging.info("No output received from Tradewars server (timeout).")
             reply = ""
     except Exception as e:
         logging.error(f"Error communicating with TradeWars server: {e}")


### PR DESCRIPTION
## Summary
- avoid raising a connection error when Tradewars sends an empty reply
- log when no output is received instead of treating it as a failure

## Testing
- `python -m py_compile command_handlers.py`
- `ruff check .` *(fails: `meshtastic.BROADCAST_NUM` imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_6882a31667e8832187366ee7a550412c