### PR TITLE
Update bulletin board flow

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -380,7 +380,10 @@ def handle_bb_steps(sender_id, message, step, state, interface, bbs_nodes):
         sender_short_name, date, subject, content, unique_id = get_bulletin_content(bulletin_id)
         send_message(f"From: {sender_short_name}\nDate: {date}\nSubject: {subject}\n- - - - - - -\n{content}", sender_id, interface)
         board_name = state['board']
-        handle_bb_steps(sender_id, 'e', 1, state, interface, bbs_nodes)
+        # After displaying the selected bulletin return to the list of
+        # bulletins for the same board so the user can easily select the next
+        # message without navigating through the BBS menu again.
+        handle_bb_steps(sender_id, 'r', 2, state, interface, bbs_nodes)
 
     elif step == 4:
         subject = message


### PR DESCRIPTION
## Summary
- redisplay the bulletin list after reading a post so users can continue browsing without reselecting the board

## Testing
- `python -m py_compile command_handlers.py message_processing.py utils.py db_operations.py js8call_integration.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_688403c23aa8832199f4ff044bf80df5